### PR TITLE
Only load .vec and .audio when needed

### DIFF
--- a/Final_Project_Temp/CSCI576_FinalProject/CSCI576_FinalProject/DominantColorList.cpp
+++ b/Final_Project_Temp/CSCI576_FinalProject/CSCI576_FinalProject/DominantColorList.cpp
@@ -117,26 +117,28 @@ void DominantColorList::dumpData(string filepath) {
 	}
 	of2.close();
 }
-void DominantColorList::populateData(string filepath) {
-	std::ifstream if1(filepath + ".hue");
+void DominantColorList::populateDataHue(string filepath) {
+	std::ifstream ifs(filepath + ".hue");
 	int hueExist;
 	int i = 0;
-	while(if1 >> hueExist){
+	while(ifs >> hueExist){
 		dominantHues[i++] = hueExist;
 		if (hueExist == 0) ++numUnusedHues;
 	}
-	if1.close();
-	
-	std::ifstream if2(filepath + ".vec");
+	ifs.close();
+}
+
+void DominantColorList::populateDataVec(string filepath) {
+	std::ifstream ifs(filepath + ".vec");
 	int a; int b; int c;
-	while (if2 >> a >> b >> c){
+	while (ifs >> a >> b >> c) {
 		int* colors = new int[3];
 		colors[0] = a;
 		colors[1] = b;
 		colors[2] = c;
 		validHues.push_back(colors);
 	}
-	if2.close();
+	ifs.close();
 }
 
 Mat DominantColorList::findFirstFrame(int i) {

--- a/Final_Project_Temp/CSCI576_FinalProject/CSCI576_FinalProject/DominantColorList.h
+++ b/Final_Project_Temp/CSCI576_FinalProject/CSCI576_FinalProject/DominantColorList.h
@@ -36,7 +36,8 @@ public:
 
 
 	void dumpData(string fileInput);
-	void populateData(string fileInput);
+	void populateDataHue(string fileInput);
+	void populateDataVec(string fileInput);
 	void setSrcVideo(string s) { srcVideo = s; };
 
 	Mat findFirstFrame(int i);

--- a/Final_Project_Temp/CSCI576_FinalProject/CSCI576_FinalProject/MultiMediaSearcher.cpp
+++ b/Final_Project_Temp/CSCI576_FinalProject/CSCI576_FinalProject/MultiMediaSearcher.cpp
@@ -31,13 +31,12 @@ void MultiMediaSearcher::search() {
 		srcVideo.setSrcVideo(srcVideoPath + std::to_string(i) + ".mp4");
 		srcVideo.populateDataHue(f);
 
-		AudioHandler srcAudio = AudioHandler::AudioHandler();
-		srcAudio.populateData(f);
-
 		if (srcVideo.checkHueSpectrum(&subVideo)) {
 			srcVideo.populateDataVec(f);
 			//if (srcVideo.getNumUnusedHues() > 200) {
 			if (i==1 || i==6 || i==9 || i ==10) {
+				AudioHandler srcAudio = AudioHandler::AudioHandler();
+				srcAudio.populateData(f);
 				int temp_index = srcAudio.compareAudio(&subAudio);
 				if (srcVideo.acceptableColorIndex(temp_index, &subVideo)){
 					index = temp_index;

--- a/Final_Project_Temp/CSCI576_FinalProject/CSCI576_FinalProject/MultiMediaSearcher.cpp
+++ b/Final_Project_Temp/CSCI576_FinalProject/CSCI576_FinalProject/MultiMediaSearcher.cpp
@@ -29,12 +29,13 @@ void MultiMediaSearcher::search() {
 
 		DominantColorList srcVideo = DominantColorList();
 		srcVideo.setSrcVideo(srcVideoPath + std::to_string(i) + ".mp4");
-		srcVideo.populateData(f);
+		srcVideo.populateDataHue(f);
 
 		AudioHandler srcAudio = AudioHandler::AudioHandler();
 		srcAudio.populateData(f);
 
 		if (srcVideo.checkHueSpectrum(&subVideo)) {
+			srcVideo.populateDataVec(f);
 			//if (srcVideo.getNumUnusedHues() > 200) {
 			if (i==1 || i==6 || i==9 || i ==10) {
 				int temp_index = srcAudio.compareAudio(&subAudio);


### PR DESCRIPTION
Only populating the validHues vector from .vec when the query hues match the src hues so we don't have to load in all the frames for every single src video. This reduces the search time by around 40% (5s->3s when looking for video11_1), and the time save becomes more significant the more videos the search has to look through.
Also only create an AudioHandler when needed as well.